### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=5.5.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0"
+    "phpunit/phpunit": "~4.8.35"
   },
   "autoload": {
     "files": ["src/transducers.php"]

--- a/tests/transducersTest.php
+++ b/tests/transducersTest.php
@@ -1,9 +1,10 @@
 <?php
 namespace transducers\Tests;
 
+use PHPUnit\Framework\TestCase;
 use transducers as t;
 
-class functionsTest extends \PHPUnit_Framework_TestCase
+class functionsTest extends TestCase
 {
     public function testComposesFunctions()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.